### PR TITLE
Bumped API & React Package Versions

### DIFF
--- a/api/middlewares/connectToMongo.js
+++ b/api/middlewares/connectToMongo.js
@@ -5,7 +5,7 @@ exports.connectToMongoDB = () => {
     const DATABASE_URL =
         process.env.DATABASE_URL || 'mongodb://127.0.0.1:27017/petStoreDB';
 
-    mongoose.connect(DATABASE_URL, { useNewUrlParser: true });
+    mongoose.connect(DATABASE_URL);
     const db = mongoose.connection;
 
     db.on('error', (error) => {

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -14,7 +14,7 @@
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
         "jwt-simple": "^0.5.6",
-        "mongoose": "^7.6.3",
+        "mongoose": "^8.0.1",
         "nodemon": "^3.0.1",
         "passport": "^0.6.0",
         "passport-jwt": "^4.0.1",
@@ -54,26 +54,25 @@
       }
     },
     "node_modules/@mongodb-js/saslprep": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.0.tgz",
-      "integrity": "sha512-Xfijy7HvfzzqiOAhAepF4SGN5e9leLkMvg/OPOF97XemjfVCYN/oWa75wnkc6mltMSTwY+XlbhWgUOJmkFspSw==",
-      "optional": true,
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.1.tgz",
+      "integrity": "sha512-t7c5K033joZZMspnHg/gWPE4kandgc2OxE74aYOtGKfgB9VPuVJPix0H6fhmm2erj5PBJ21mqcx34lpIGtUCsQ==",
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
       }
     },
     "node_modules/@types/node": {
-      "version": "20.8.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.7.tgz",
-      "integrity": "sha512-21TKHHh3eUHIi2MloeptJWALuCu5H7HQTdTrWIFReA8ad+aggoX+lRes3ex7/FtpC+sVUpFMQ+QTfYr74mruiQ==",
+      "version": "20.9.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.3.tgz",
+      "integrity": "sha512-nk5wXLAXGBKfrhLB0cyHGbSqopS+nz0BUgZkUQqSHSSgdee0kssp1IAqlQOu333bW+gMNs2QREx7iynm19Abxw==",
       "dependencies": {
-        "undici-types": "~5.25.1"
+        "undici-types": "~5.26.4"
       }
     },
     "node_modules/@types/webidl-conversions": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.2.tgz",
-      "integrity": "sha512-uNv6b/uGRLlCVmelat2rA8bcVd3k/42mV2EmjhPh6JLkd35T5bgwR/t6xy7a9MWhd9sixIeBUzhBenvk3NO+DQ=="
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
+      "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA=="
     },
     "node_modules/@types/whatwg-url": {
       "version": "8.2.2",
@@ -245,11 +244,11 @@
       }
     },
     "node_modules/bson": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-5.5.1.tgz",
-      "integrity": "sha512-ix0EwukN2EpC0SRWIj/7B5+A6uQMQy6KMREI9qQqvgpkV2frH63T0UDVd1SYedL6dNCmDBYB3QtXi4ISk9YT+g==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.2.0.tgz",
+      "integrity": "sha512-ID1cI+7bazPDyL9wYy9GaQ8gEEohWvcUl/Yf0dIdutJxnmInEEyCsb4awy/OiBfall7zBA179Pahi3vCdFze3Q==",
       "engines": {
-        "node": ">=14.20.1"
+        "node": ">=16.20.1"
       }
     },
     "node_modules/buffer-equal-constant-time": {
@@ -817,11 +816,6 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
-    "node_modules/ip": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
-      "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ=="
-    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -1016,8 +1010,7 @@
     "node_modules/memory-pager": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
-      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
-      "optional": true
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg=="
     },
     "node_modules/merge-descriptors": {
       "version": "1.0.1",
@@ -1116,32 +1109,34 @@
       }
     },
     "node_modules/mongodb": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.9.0.tgz",
-      "integrity": "sha512-g+GCMHN1CoRUA+wb1Agv0TI4YTSiWr42B5ulkiAfLLHitGK1R+PkSAf3Lr5rPZwi/3F04LiaZEW0Kxro9Fi2TA==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.2.0.tgz",
+      "integrity": "sha512-d7OSuGjGWDZ5usZPqfvb36laQ9CPhnWkAGHT61x5P95p/8nMVeH8asloMwW6GcYFeB0Vj4CB/1wOTDG2RA9BFA==",
       "dependencies": {
-        "bson": "^5.5.0",
-        "mongodb-connection-string-url": "^2.6.0",
-        "socks": "^2.7.1"
+        "@mongodb-js/saslprep": "^1.1.0",
+        "bson": "^6.2.0",
+        "mongodb-connection-string-url": "^2.6.0"
       },
       "engines": {
-        "node": ">=14.20.1"
-      },
-      "optionalDependencies": {
-        "@mongodb-js/saslprep": "^1.1.0"
+        "node": ">=16.20.1"
       },
       "peerDependencies": {
         "@aws-sdk/credential-providers": "^3.188.0",
-        "@mongodb-js/zstd": "^1.0.0",
-        "kerberos": "^1.0.0 || ^2.0.0",
-        "mongodb-client-encryption": ">=2.3.0 <3",
-        "snappy": "^7.2.2"
+        "@mongodb-js/zstd": "^1.1.0",
+        "gcp-metadata": "^5.2.0",
+        "kerberos": "^2.0.1",
+        "mongodb-client-encryption": ">=6.0.0 <7",
+        "snappy": "^7.2.2",
+        "socks": "^2.7.1"
       },
       "peerDependenciesMeta": {
         "@aws-sdk/credential-providers": {
           "optional": true
         },
         "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "gcp-metadata": {
           "optional": true
         },
         "kerberos": {
@@ -1151,6 +1146,9 @@
           "optional": true
         },
         "snappy": {
+          "optional": true
+        },
+        "socks": {
           "optional": true
         }
       }
@@ -1165,20 +1163,20 @@
       }
     },
     "node_modules/mongoose": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-7.6.3.tgz",
-      "integrity": "sha512-moYP2qWCOdWRDeBxqB/zYwQmQnTBsF5DoolX5uPyI218BkiA1ujGY27P0NTd4oWIX+LLkZPw0LDzlc/7oh1plg==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.0.1.tgz",
+      "integrity": "sha512-O3TJrtLCt4H1eGf2HoHGcnOcCTWloQkpmIP3hA9olybX3OX2KUjdIIq135HD5paGjZEDJYKn9fw4eH5N477zqQ==",
       "dependencies": {
-        "bson": "^5.5.0",
+        "bson": "^6.2.0",
         "kareem": "2.5.1",
-        "mongodb": "5.9.0",
+        "mongodb": "6.2.0",
         "mpath": "0.9.0",
         "mquery": "5.0.0",
         "ms": "2.1.3",
         "sift": "16.0.1"
       },
       "engines": {
-        "node": ">=14.20.1"
+        "node": ">=16.20.1"
       },
       "funding": {
         "type": "opencollective",
@@ -1511,9 +1509,9 @@
       "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w=="
     },
     "node_modules/punycode": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "engines": {
         "node": ">=6"
       }
@@ -1730,33 +1728,10 @@
         "node": ">=10"
       }
     },
-    "node_modules/smart-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
-      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-      "engines": {
-        "node": ">= 6.0.0",
-        "npm": ">= 3.0.0"
-      }
-    },
-    "node_modules/socks": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
-      "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
-      "dependencies": {
-        "ip": "^2.0.0",
-        "smart-buffer": "^4.2.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0",
-        "npm": ">= 3.0.0"
-      }
-    },
     "node_modules/sparse-bitfield": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
       "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
-      "optional": true,
       "dependencies": {
         "memory-pager": "^1.0.2"
       }
@@ -1901,9 +1876,9 @@
       "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA=="
     },
     "node_modules/undici-types": {
-      "version": "5.25.3",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.25.3.tgz",
-      "integrity": "sha512-Ga1jfYwRn7+cP9v8auvEXN1rX3sWqlayd4HP7OKk4mZWylEmu3KzXDUGrQUN6Ol7qo1gPvB2e5gX6udnyEPgdA=="
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/api/package.json
+++ b/api/package.json
@@ -15,7 +15,7 @@
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "jwt-simple": "^0.5.6",
-    "mongoose": "^7.6.3",
+    "mongoose": "^8.0.1",
     "nodemon": "^3.0.1",
     "passport": "^0.6.0",
     "passport-jwt": "^4.0.1",

--- a/reactjs/package-lock.json
+++ b/reactjs/package-lock.json
@@ -8,23 +8,23 @@
             "name": "reactjs",
             "version": "1.0.0",
             "dependencies": {
-                "@vitejs/plugin-react-swc": "^3.4.0",
-                "axios": "^1.5.1",
+                "@vitejs/plugin-react-swc": "^3.5.0",
+                "axios": "^1.6.2",
                 "prop-types": "^15.8.1",
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0",
-                "react-router-dom": "^6.17.0",
-                "styled-components": "^6.1.0",
+                "react-router-dom": "^6.19.0",
+                "styled-components": "^6.1.1",
                 "vite": "^4.5.0",
                 "wdv_crud-api": "file:.."
             },
             "devDependencies": {
-                "@types/react": "^18.2.31",
-                "@types/react-dom": "^18.2.14",
-                "eslint": "^8.52.0",
+                "@types/react": "^18.2.38",
+                "@types/react-dom": "^18.2.16",
+                "eslint": "^8.54.0",
                 "eslint-plugin-react": "^7.33.2",
                 "eslint-plugin-react-hooks": "^4.6.0",
-                "eslint-plugin-react-refresh": "^0.4.3"
+                "eslint-plugin-react-refresh": "^0.4.4"
             }
         },
         "..": {
@@ -411,18 +411,18 @@
             }
         },
         "node_modules/@eslint-community/regexpp": {
-            "version": "4.9.1",
-            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.9.1.tgz",
-            "integrity": "sha512-Y27x+MBLjXa+0JWDhykM3+JE+il3kHKAEqabfEWq3SDhZjLYb6/BHL/JKFnH3fe207JaXkyDo685Oc2Glt6ifA==",
+            "version": "4.10.0",
+            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.0.tgz",
+            "integrity": "sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==",
             "dev": true,
             "engines": {
                 "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
             }
         },
         "node_modules/@eslint/eslintrc": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.2.tgz",
-            "integrity": "sha512-+wvgpDsrB1YqAMdEUCcnTlpfVBH7Vqn6A/NT3D8WVXFIaKMlErPIZT3oCIAVCOtarRpMtelZLqJeU3t7WY6X6g==",
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.3.tgz",
+            "integrity": "sha512-yZzuIG+jnVu6hNSzFEN07e8BxF3uAzYtQb6uDkaYZLo6oYZDCq454c5kB8zxnzfCYyP4MIuyBn10L0DqwujTmA==",
             "dev": true,
             "dependencies": {
                 "ajv": "^6.12.4",
@@ -443,9 +443,9 @@
             }
         },
         "node_modules/@eslint/js": {
-            "version": "8.52.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.52.0.tgz",
-            "integrity": "sha512-mjZVbpaeMZludF2fsWLD0Z9gCref1Tk4i9+wddjRvpUNqqcndPkBD09N/Mapey0b3jaXbLm2kICwFv2E64QinA==",
+            "version": "8.54.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.54.0.tgz",
+            "integrity": "sha512-ut5V+D+fOoWPgGGNj83GGjnntO39xDy6DWxO0wb7Jp3DcMX0TfIqdzHF85VTQkerdyGmuuMD9AKAo5KiNlf/AQ==",
             "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -520,17 +520,17 @@
             }
         },
         "node_modules/@remix-run/router": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.10.0.tgz",
-            "integrity": "sha512-Lm+fYpMfZoEucJ7cMxgt4dYt8jLfbpwRCzAjm9UgSLOkmlqo9gupxt6YX3DY0Fk155NT9l17d/ydi+964uS9Lw==",
+            "version": "1.12.0",
+            "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.12.0.tgz",
+            "integrity": "sha512-2hXv036Bux90e1GXTWSMfNzfDDK8LA8JYEWfyHxzvwdp6GyoWEovKc9cotb3KCKmkdwsIBuFGX7ScTWyiHv7Eg==",
             "engines": {
                 "node": ">=14.0.0"
             }
         },
         "node_modules/@swc/core": {
-            "version": "1.3.94",
-            "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.94.tgz",
-            "integrity": "sha512-jTHn8UJOGgERKZLy8euEixVAzC/w/rUSuMlM3e7hxgap/TC595hSkuQwtkpL238dsuEPveD44GMy2A5UBtSvjg==",
+            "version": "1.3.99",
+            "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.99.tgz",
+            "integrity": "sha512-8O996RfuPC4ieb4zbYMfbyCU9k4gSOpyCNnr7qBQ+o7IEmh8JCV6B8wwu+fT/Om/6Lp34KJe1IpJ/24axKS6TQ==",
             "hasInstallScript": true,
             "dependencies": {
                 "@swc/counter": "^0.1.1",
@@ -544,16 +544,15 @@
                 "url": "https://opencollective.com/swc"
             },
             "optionalDependencies": {
-                "@swc/core-darwin-arm64": "1.3.94",
-                "@swc/core-darwin-x64": "1.3.94",
-                "@swc/core-linux-arm-gnueabihf": "1.3.94",
-                "@swc/core-linux-arm64-gnu": "1.3.94",
-                "@swc/core-linux-arm64-musl": "1.3.94",
-                "@swc/core-linux-x64-gnu": "1.3.94",
-                "@swc/core-linux-x64-musl": "1.3.94",
-                "@swc/core-win32-arm64-msvc": "1.3.94",
-                "@swc/core-win32-ia32-msvc": "1.3.94",
-                "@swc/core-win32-x64-msvc": "1.3.94"
+                "@swc/core-darwin-arm64": "1.3.99",
+                "@swc/core-darwin-x64": "1.3.99",
+                "@swc/core-linux-arm64-gnu": "1.3.99",
+                "@swc/core-linux-arm64-musl": "1.3.99",
+                "@swc/core-linux-x64-gnu": "1.3.99",
+                "@swc/core-linux-x64-musl": "1.3.99",
+                "@swc/core-win32-arm64-msvc": "1.3.99",
+                "@swc/core-win32-ia32-msvc": "1.3.99",
+                "@swc/core-win32-x64-msvc": "1.3.99"
             },
             "peerDependencies": {
                 "@swc/helpers": "^0.5.0"
@@ -565,9 +564,9 @@
             }
         },
         "node_modules/@swc/core-darwin-arm64": {
-            "version": "1.3.94",
-            "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.94.tgz",
-            "integrity": "sha512-KNuE6opIy/wAXiGUWLhGWhCG3wA/AdjG6eYkv6dstrAURLaQMAoD8vDfVm8pxS8FA8Kx+0Z4QiDNPqk5aKIsqg==",
+            "version": "1.3.99",
+            "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.99.tgz",
+            "integrity": "sha512-Qj7Jct68q3ZKeuJrjPx7k8SxzWN6PqLh+VFxzA+KwLDpQDPzOlKRZwkIMzuFjLhITO4RHgSnXoDk/Syz0ZeN+Q==",
             "cpu": [
                 "arm64"
             ],
@@ -580,9 +579,9 @@
             }
         },
         "node_modules/@swc/core-darwin-x64": {
-            "version": "1.3.94",
-            "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.94.tgz",
-            "integrity": "sha512-HypemhyehQrLqXwfJv5ronD4BMAXdgMCP4Ei7rt3B6Ftmt9axwGvdwGiXxsYR9h1ncyxoVxN+coGxbNIhKhahw==",
+            "version": "1.3.99",
+            "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.99.tgz",
+            "integrity": "sha512-wR7m9QVJjgiBu1PSOHy7s66uJPa45Kf9bZExXUL+JAa9OQxt5y+XVzr+n+F045VXQOwdGWplgPnWjgbUUHEVyw==",
             "cpu": [
                 "x64"
             ],
@@ -594,25 +593,10 @@
                 "node": ">=10"
             }
         },
-        "node_modules/@swc/core-linux-arm-gnueabihf": {
-            "version": "1.3.94",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.94.tgz",
-            "integrity": "sha512-KzKN54c7Y6X1db+bBVSXG4+bXmAPvXtDWk+TgwNJH4yYliOrnP/RKkHA5QZ9VFSnqJF06/sAO4kYBiL/aVQDBQ==",
-            "cpu": [
-                "arm"
-            ],
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/@swc/core-linux-arm64-gnu": {
-            "version": "1.3.94",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.94.tgz",
-            "integrity": "sha512-iAcR8Ho0Uck/SLSrgYfXkpcGOXuN5waMZO7GlL/52QODr7GJtOfZ0H1MCZLbIFkPJp/iXoJpYgym4d/qSd477Q==",
+            "version": "1.3.99",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.99.tgz",
+            "integrity": "sha512-gcGv1l5t0DScEONmw5OhdVmEI/o49HCe9Ik38zzH0NtDkc+PDYaCcXU5rvfZP2qJFaAAr8cua8iJcOunOSLmnA==",
             "cpu": [
                 "arm64"
             ],
@@ -625,9 +609,9 @@
             }
         },
         "node_modules/@swc/core-linux-arm64-musl": {
-            "version": "1.3.94",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.94.tgz",
-            "integrity": "sha512-VCHL1Mb9ENHx+sAeubSSg481MUeP9/PYzPPy9tfswunj/w35M+vEWflwK2dzQL9kUTFD3zcFTpAgsKnj6aX24w==",
+            "version": "1.3.99",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.99.tgz",
+            "integrity": "sha512-XL1/eUsTO8BiKsWq9i3iWh7H99iPO61+9HYiWVKhSavknfj4Plbn+XyajDpxsauln5o8t+BRGitymtnAWJM4UQ==",
             "cpu": [
                 "arm64"
             ],
@@ -640,9 +624,9 @@
             }
         },
         "node_modules/@swc/core-linux-x64-gnu": {
-            "version": "1.3.94",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.94.tgz",
-            "integrity": "sha512-gjq7U6clhJi0Oel2a4gwR4MbSu+THQ2hmBNVCOSA3JjPZWZTkJXaJDpnh/r7PJxKBwUDlo0VPlwiwjepAQR2Rw==",
+            "version": "1.3.99",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.99.tgz",
+            "integrity": "sha512-fGrXYE6DbTfGNIGQmBefYxSk3rp/1lgbD0nVg4rl4mfFRQPi7CgGhrrqSuqZ/ezXInUIgoCyvYGWFSwjLXt/Qg==",
             "cpu": [
                 "x64"
             ],
@@ -655,9 +639,9 @@
             }
         },
         "node_modules/@swc/core-linux-x64-musl": {
-            "version": "1.3.94",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.94.tgz",
-            "integrity": "sha512-rSylruWyeol2ujZDHmwiovupMR5ukMXivlA7DDxmQ1dFUV9HuiPknQrU5rEbI3V2V3V5RkpbEKjnADen7AeMPQ==",
+            "version": "1.3.99",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.99.tgz",
+            "integrity": "sha512-kvgZp/mqf3IJ806gUOL6gN6VU15+DfzM1Zv4Udn8GqgXiUAvbQehrtruid4Snn5pZTLj4PEpSCBbxgxK1jbssA==",
             "cpu": [
                 "x64"
             ],
@@ -670,9 +654,9 @@
             }
         },
         "node_modules/@swc/core-win32-arm64-msvc": {
-            "version": "1.3.94",
-            "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.94.tgz",
-            "integrity": "sha512-OenDUr5MQkz506ebVQq6ezoZ3GZ26nchgf5mPnwab4gx2TEiyR9zn7MdX5LWskTmOK3+FszPbGK0B5oLK6Y5yw==",
+            "version": "1.3.99",
+            "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.99.tgz",
+            "integrity": "sha512-yt8RtZ4W/QgFF+JUemOUQAkVW58cCST7mbfKFZ1v16w3pl3NcWd9OrtppFIXpbjU1rrUX2zp2R7HZZzZ2Zk/aQ==",
             "cpu": [
                 "arm64"
             ],
@@ -685,9 +669,9 @@
             }
         },
         "node_modules/@swc/core-win32-ia32-msvc": {
-            "version": "1.3.94",
-            "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.94.tgz",
-            "integrity": "sha512-mi6NcmtJKnaiHAxLtVz+WzunscsEwPdA0j15DuiYVx06Xo+MdRLJj4eVBgVLwGD1AI3IqKs4MVVx2cD7n0h5mg==",
+            "version": "1.3.99",
+            "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.99.tgz",
+            "integrity": "sha512-62p5fWnOJR/rlbmbUIpQEVRconICy5KDScWVuJg1v3GPLBrmacjphyHiJC1mp6dYvvoEWCk/77c/jcQwlXrDXw==",
             "cpu": [
                 "ia32"
             ],
@@ -700,9 +684,9 @@
             }
         },
         "node_modules/@swc/core-win32-x64-msvc": {
-            "version": "1.3.94",
-            "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.94.tgz",
-            "integrity": "sha512-Ba0ZLcGMnqPWWF9Xa+rWhhnkpvE7XoQegMP/VCF2JIHb2ieGBC8jChO6nKRFKZjib/3wghGzxakyDQx3LDhDug==",
+            "version": "1.3.99",
+            "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.99.tgz",
+            "integrity": "sha512-PdppWhkoS45VGdMBxvClVgF1hVjqamtvYd82Gab1i4IV45OSym2KinoDCKE1b6j3LwBLOn2J9fvChGSgGfDCHQ==",
             "cpu": [
                 "x64"
             ],
@@ -725,15 +709,15 @@
             "integrity": "sha512-myfUej5naTBWnqOCc/MdVOLVjXUXtIA+NpDrDBKJtLLg2shUjBu3cZmB/85RyitKc55+lUUyl7oRfLOvkr2hsw=="
         },
         "node_modules/@types/prop-types": {
-            "version": "15.7.9",
-            "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.9.tgz",
-            "integrity": "sha512-n1yyPsugYNSmHgxDFjicaI2+gCNjsBck8UX9kuofAKlc0h1bL+20oSF72KeNaW2DUlesbEVCFgyV2dPGTiY42g==",
+            "version": "15.7.11",
+            "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.11.tgz",
+            "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==",
             "dev": true
         },
         "node_modules/@types/react": {
-            "version": "18.2.31",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.31.tgz",
-            "integrity": "sha512-c2UnPv548q+5DFh03y8lEDeMfDwBn9G3dRwfkrxQMo/dOtRHUUO57k6pHvBIfH/VF4Nh+98mZ5aaSe+2echD5g==",
+            "version": "18.2.38",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.38.tgz",
+            "integrity": "sha512-cBBXHzuPtQK6wNthuVMV6IjHAFkdl/FOPFIlkd81/Cd1+IqkHu/A+w4g43kaQQoYHik/ruaQBDL72HyCy1vuMw==",
             "dev": true,
             "dependencies": {
                 "@types/prop-types": "*",
@@ -742,24 +726,24 @@
             }
         },
         "node_modules/@types/react-dom": {
-            "version": "18.2.14",
-            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.14.tgz",
-            "integrity": "sha512-V835xgdSVmyQmI1KLV2BEIUgqEuinxp9O4G6g3FqO/SqLac049E53aysv0oEFD2kHfejeKU+ZqL2bcFWj9gLAQ==",
+            "version": "18.2.16",
+            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.16.tgz",
+            "integrity": "sha512-766c37araZ9vxtYs25gvY2wNdFWsT2ZiUvOd0zMhTaoGj6B911N8CKQWgXXJoPMLF3J82thpRqQA7Rf3rBwyJw==",
             "dev": true,
             "dependencies": {
                 "@types/react": "*"
             }
         },
         "node_modules/@types/scheduler": {
-            "version": "0.16.5",
-            "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.5.tgz",
-            "integrity": "sha512-s/FPdYRmZR8SjLWGMCuax7r3qCWQw9QKHzXVukAuuIJkXkDRwp+Pu5LMIVFi0Fxbav35WURicYr8u1QsoybnQw==",
+            "version": "0.16.7",
+            "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.7.tgz",
+            "integrity": "sha512-8g25Nl3AuB1KulTlSUsUhUo/oBgBU6XIXQ+XURpeioEbEJvkO7qI4vDfREv3vJYHHzqXjcAHvoJy4pTtSQNZtA==",
             "dev": true
         },
         "node_modules/@types/stylis": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.2.tgz",
-            "integrity": "sha512-Rm17MsTpQQP5Jq4BF7CdrxJsDufoiL/q5IbJZYZmOZAJALyijgF7BzLgobXUqraNcQdqFYLYGeglDp6QzaxPpg=="
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.3.tgz",
+            "integrity": "sha512-86XLCVEmWagiUEbr2AjSbeY4qHN9jMm3pgM3PuBYfLIbT0MpDSnA3GA/4W7KoH/C/eeK77kNaeIxZzjhKYIBgw=="
         },
         "node_modules/@ungap/structured-clone": {
             "version": "1.2.0",
@@ -768,20 +752,20 @@
             "dev": true
         },
         "node_modules/@vitejs/plugin-react-swc": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/@vitejs/plugin-react-swc/-/plugin-react-swc-3.4.0.tgz",
-            "integrity": "sha512-m7UaA4Uvz82N/0EOVpZL4XsFIakRqrFKeSNxa1FBLSXGvWrWRBwmZb4qxk+ZIVAZcW3c3dn5YosomDgx62XWcQ==",
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/@vitejs/plugin-react-swc/-/plugin-react-swc-3.5.0.tgz",
+            "integrity": "sha512-1PrOvAaDpqlCV+Up8RkAh9qaiUjoDUcjtttyhXDKw53XA6Ve16SOp6cCOpRs8Dj8DqUQs6eTW5YkLcLJjrXAig==",
             "dependencies": {
-                "@swc/core": "^1.3.85"
+                "@swc/core": "^1.3.96"
             },
             "peerDependencies": {
-                "vite": "^4"
+                "vite": "^4 || ^5"
             }
         },
         "node_modules/acorn": {
-            "version": "8.10.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
-            "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+            "version": "8.11.2",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
+            "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
             "dev": true,
             "bin": {
                 "acorn": "bin/acorn"
@@ -974,9 +958,9 @@
             }
         },
         "node_modules/axios": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.1.tgz",
-            "integrity": "sha512-Q28iYCWzNHjAm+yEAot5QaAMxhMghWLFVf7rRdwhUI+c2jix2DUXjAHXVi+s1ibs3mjPO/cCgbA++3BjD0vP/A==",
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
+            "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
             "dependencies": {
                 "follow-redirects": "^1.15.0",
                 "form-data": "^4.0.0",
@@ -1356,15 +1340,15 @@
             }
         },
         "node_modules/eslint": {
-            "version": "8.52.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.52.0.tgz",
-            "integrity": "sha512-zh/JHnaixqHZsolRB/w9/02akBk9EPrOs9JwcTP2ek7yL5bVvXuRariiaAjjoJ5DvuwQ1WAE/HsMz+w17YgBCg==",
+            "version": "8.54.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.54.0.tgz",
+            "integrity": "sha512-NY0DfAkM8BIZDVl6PgSa1ttZbx3xHgJzSNJKYcQglem6CppHyMhRIQkBVSSMaSRnLhig3jsDbEzOjwCVt4AmmA==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
-                "@eslint/eslintrc": "^2.1.2",
-                "@eslint/js": "8.52.0",
+                "@eslint/eslintrc": "^2.1.3",
+                "@eslint/js": "8.54.0",
                 "@humanwhocodes/config-array": "^0.11.13",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@nodelib/fs.walk": "^1.2.8",
@@ -1453,9 +1437,9 @@
             }
         },
         "node_modules/eslint-plugin-react-refresh": {
-            "version": "0.4.3",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.3.tgz",
-            "integrity": "sha512-Hh0wv8bUNY877+sI0BlCUlsS0TYYQqvzEwJsJJPM2WF4RnTStSnSR3zdJYa2nPOJgg3UghXi54lVyMSmpCalzA==",
+            "version": "0.4.4",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.4.tgz",
+            "integrity": "sha512-eD83+65e8YPVg6603Om2iCIwcQJf/y7++MWm4tACtEswFLYMwxwVWAfwN+e19f5Ad/FOyyNg9Dfi5lXhH3Y3rA==",
             "dev": true,
             "peerDependencies": {
                 "eslint": ">=7"
@@ -1616,9 +1600,9 @@
             }
         },
         "node_modules/flat-cache": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.1.1.tgz",
-            "integrity": "sha512-/qM2b3LUIaIgviBQovTLvijfyOQXPtSRnRK26ksj2J7rzPIecePUIpJsZ4T02Qg+xiAEKIs5K8dsHEd+VaKa/Q==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
+            "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
             "dev": true,
             "dependencies": {
                 "flatted": "^3.2.9",
@@ -1626,7 +1610,7 @@
                 "rimraf": "^3.0.2"
             },
             "engines": {
-                "node": ">=12.0.0"
+                "node": "^10.12.0 || >=12.0.0"
             }
         },
         "node_modules/flatted": {
@@ -1924,9 +1908,9 @@
             }
         },
         "node_modules/ignore": {
-            "version": "5.2.4",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
-            "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.0.tgz",
+            "integrity": "sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==",
             "dev": true,
             "engines": {
                 "node": ">= 4"
@@ -2459,9 +2443,9 @@
             "dev": true
         },
         "node_modules/nanoid": {
-            "version": "3.3.6",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-            "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+            "version": "3.3.7",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+            "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
             "funding": [
                 {
                     "type": "github",
@@ -2749,9 +2733,9 @@
             "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
         },
         "node_modules/punycode": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-            "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+            "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
             "dev": true,
             "engines": {
                 "node": ">=6"
@@ -2806,11 +2790,11 @@
             "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         },
         "node_modules/react-router": {
-            "version": "6.17.0",
-            "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.17.0.tgz",
-            "integrity": "sha512-YJR3OTJzi3zhqeJYADHANCGPUu9J+6fT5GLv82UWRGSxu6oJYCKVmxUcaBQuGm9udpWmPsvpme/CdHumqgsoaA==",
+            "version": "6.19.0",
+            "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.19.0.tgz",
+            "integrity": "sha512-0W63PKCZ7+OuQd7Tm+RbkI8kCLmn4GPjDbX61tWljPxWgqTKlEpeQUwPkT1DRjYhF8KSihK0hQpmhU4uxVMcdw==",
             "dependencies": {
-                "@remix-run/router": "1.10.0"
+                "@remix-run/router": "1.12.0"
             },
             "engines": {
                 "node": ">=14.0.0"
@@ -2820,12 +2804,12 @@
             }
         },
         "node_modules/react-router-dom": {
-            "version": "6.17.0",
-            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.17.0.tgz",
-            "integrity": "sha512-qWHkkbXQX+6li0COUUPKAUkxjNNqPJuiBd27dVwQGDNsuFBdMbrS6UZ0CLYc4CsbdLYTckn4oB4tGDuPZpPhaQ==",
+            "version": "6.19.0",
+            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.19.0.tgz",
+            "integrity": "sha512-N6dWlcgL2w0U5HZUUqU2wlmOrSb3ighJmtQ438SWbhB1yuLTXQ8yyTBMK3BSvVjp7gBtKurT554nCtMOgxCZmQ==",
             "dependencies": {
-                "@remix-run/router": "1.10.0",
-                "react-router": "6.17.0"
+                "@remix-run/router": "1.12.0",
+                "react-router": "6.19.0"
             },
             "engines": {
                 "node": ">=14.0.0"
@@ -3177,9 +3161,9 @@
             }
         },
         "node_modules/styled-components": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.1.0.tgz",
-            "integrity": "sha512-VWNfYYBuXzuLS/QYEeoPgMErP26WL+dX9//rEh80B2mmlS1yRxRxuL5eax4m6ybYEUoHWlTy2XOU32767mlMkg==",
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.1.1.tgz",
+            "integrity": "sha512-cpZZP5RrKRIClBW5Eby4JM1wElLVP4NQrJbJ0h10TidTyJf4SIIwa3zLXOoPb4gJi8MsJ8mjq5mu2IrEhZIAcQ==",
             "dependencies": {
                 "@emotion/is-prop-valid": "^1.2.1",
                 "@emotion/unitless": "^0.8.0",

--- a/reactjs/package.json
+++ b/reactjs/package.json
@@ -11,22 +11,22 @@
         "preview": "vite preview"
     },
     "dependencies": {
-        "@vitejs/plugin-react-swc": "^3.4.0",
-        "axios": "^1.5.1",
+        "@vitejs/plugin-react-swc": "^3.5.0",
+        "axios": "^1.6.2",
         "prop-types": "^15.8.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-router-dom": "^6.17.0",
-        "styled-components": "^6.1.0",
+        "react-router-dom": "^6.19.0",
+        "styled-components": "^6.1.1",
         "vite": "^4.5.0",
         "wdv_crud-api": "file:.."
     },
     "devDependencies": {
-        "@types/react": "^18.2.31",
-        "@types/react-dom": "^18.2.14",
-        "eslint": "^8.52.0",
+        "@types/react": "^18.2.38",
+        "@types/react-dom": "^18.2.16",
+        "eslint": "^8.54.0",
         "eslint-plugin-react": "^7.33.2",
         "eslint-plugin-react-hooks": "^4.6.0",
-        "eslint-plugin-react-refresh": "^0.4.3"
+        "eslint-plugin-react-refresh": "^0.4.4"
     }
 }


### PR DESCRIPTION
Changes made in this commit:
- In api/package.json & package-lock.json, upgraded mongoose to 8.0.1.
- In reactjs/package.json & package-lock.json, upgraded @vitejs/plugin-react-swc, axios, react-router-dom, styled-components, eslint, @types/react, @types/react-dom, eslint-plugin-react-refresh.
- In api/middlewares/connectToMongo.js, removed deprecated useNewUrlParser option.